### PR TITLE
Allowing the library client to provide a file buffer as output target.

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ Contribute / Development
     - Update the version value in `setup.py` following semver.
     - run `./publish.sh`
 
-All options
+CLI options
 ---
 
 ```
@@ -173,4 +173,19 @@ optional arguments:
                         increase the processing time. Note: the result output
                         can be different compare to when run with multicores,
                         this is expected. Default: False
+```
+
+
+Capturing the analysis result in a buffer
+---
+
+By default, logmine writes the analysis results to stdout. In order to capture this output, a file-like object can be passed using the `set_output_file()` method to capture the result string, like in the below example :
+
+```python
+buffer = io.StringIO()
+lm = LogMine() # pass the usual parameters
+lm.output.set_output_file(file=buffer)
+lm.run()
+# The captured output can be accessed in the buffer.
+print(buffer.getvalue())
 ```

--- a/logmine_pkg/output.py
+++ b/logmine_pkg/output.py
@@ -2,6 +2,7 @@ from .pattern_generator import PatternPlaceholder
 from .variable import Variable
 from .debug import log
 import functools
+import sys
 
 
 CRED = '\33[31m'
@@ -12,6 +13,10 @@ CEND = '\033[0m'
 class Output():
     def __init__(self, options):
         self.options = options
+        self.output_file = sys.stdout
+    
+    def set_output_file(self, file):
+        self.output_file = file
 
     def out(self, clusters):
         log("Output: out", clusters)
@@ -69,4 +74,4 @@ class Output():
                     output.append(field)
 
             log("Output: start print -----------------------------------")
-            print('%s %s' % (str(count).rjust(width), ' '.join(output)))
+            print('%s %s' % (str(count).rjust(width), ' '.join(output)), file=self.output_file)


### PR DESCRIPTION
# Context and need
In our application that uses logmine for pattern recognition, we would like to send the analysis results to an api endpoint. This is not currently possible with logmine as the results are printed directly to stdout.

# Description of the change
This changes allows the clients using logmine as a library to provide a File object (for instance StringIO) in the 'outfile' configuration parameter. This analysis output will be written into this file object. The client can then read the file object to retreive the analysis result as a string/buffer.

If this parameter is not set, the code with default to stdout, which makes the change backwards compatible.