### PR TITLE
Fix pattern matching crash

### DIFF
--- a/logmine_pkg/output.py
+++ b/logmine_pkg/output.py
@@ -74,4 +74,4 @@ class Output():
                     output.append(field)
 
             log("Output: start print -----------------------------------")
-            print('%s %s' % (str(count).rjust(width), ' '.join(output)), file=self.output_file)
+            print('%s %s' % (str(count).rjust(width), ' '.join(str(_) for _ in output)), file=self.output_file)

--- a/logmine_pkg/variable.py
+++ b/logmine_pkg/variable.py
@@ -4,6 +4,8 @@ class Variable():
         self.name = name or value
 
     def __eq__(self, other):
+        if other is None:
+            return False
         if isinstance(other, str):
             return self.value == other
         return self.value == other.value


### PR DESCRIPTION
# The Issue

For some datasets, logmine crashes with the exception `AttributeError: 'NoneType' object has no attribute 'value'`.

The error happens when the comparison contains a Variable on the left operand and a None on the right operand : https://github.com/trungdq88/logmine/blob/3fa2ffcde65c284af87056c01b03a8e58f7b344d/logmine_pkg/vendor/alignment.py#L46 
This is expected as the comparison logic for Variable does not handle NoneType (only other Variables instances and strings): https://github.com/trungdq88/logmine/blob/3fa2ffcde65c284af87056c01b03a8e58f7b344d/logmine_pkg/variable.py#L6-L9 

The operands values can be of 3 types :
- None, in that case the None value is generated depending on some algorithmic state by the Smith–Waterman algorithm (https://github.com/trungdq88/logmine/blob/3fa2ffcde65c284af87056c01b03a8e58f7b344d/logmine_pkg/vendor/alignment.py#L100-L113 )
- String or Variable. These instances are generated in the processor which converts string tokens into Variables if they match the regex or pass them as strings if they do not : https://github.com/trungdq88/logmine/blob/3fa2ffcde65c284af87056c01b03a8e58f7b344d/logmine_pkg/preprocessor.py#L26-L36 

# The Fix

This PR contains two fixes ; the first solves the AttributeError crash by allowing comparisons between Variables and NoneType instances (by returning False instead of crashing). That way we restore the symmetry that is expected from an equality operator:
```python
assert not (None == Variable(...)) # worked before
assert not (Variable(...) == None) # crashed before, works now.
```

The second fix solves another issue that was probably unearthed by the first fix; under some conditions, Variable instances can end up in the output list which is passed to `"".join()`. But join() only supports lists of str instances. To avoid that, we force the str conversion before passing the items to join().